### PR TITLE
Extend the notion of sorts to handle HTS/2TT

### DIFF
--- a/theories/ExamplesUtil.v
+++ b/theories/ExamplesUtil.v
@@ -147,7 +147,9 @@ Lemma type_Eq' :
 Proof.
   intros Σ Γ A u v hg hu hv.
   destruct (istype_type hg hu) as [[] ?].
-  eapply IT.type_Eq ; eassumption.
+  eapply meta_conv.
+  - eapply IT.type_Eq ; eassumption.
+  - reflexivity.
 Defined.
 
 Lemma type_Refl' :
@@ -516,7 +518,9 @@ Lemma xtype_Eq' :
     Σ ;;; Γ |-x sEq A u v : Ty.
 Proof.
   intros Σ Γ A u v hA hu hv.
-  eapply type_Eq ; eassumption.
+  eapply xmeta_conv.
+  - eapply type_Eq ; eassumption.
+  - reflexivity.
 Defined.
 
 Lemma xtype_Refl' :

--- a/theories/FundamentalLemma.v
+++ b/theories/FundamentalLemma.v
@@ -469,7 +469,7 @@ Proof.
         eapply (@type_llift1 Sort_notion) ; eassumption.
       * lift_sort.
         eapply (@type_rlift1 Sort_notion) ; eassumption.
-    + instantiate (1 := Sorts.succ (Sorts.max s0 s2)).
+    + instantiate (1 := Sorts.succ (Sorts.prod_sort s0 s2)).
       eapply type_Heq.
       * lift_sort. eapply type_llift0 ; try eassumption.
         eapply type_conv ; try eassumption.
@@ -529,7 +529,7 @@ Proof.
         eapply (@type_llift1 Sort_notion) ; eassumption.
       * lift_sort.
         eapply (@type_rlift1 Sort_notion) ; eassumption.
-    + instantiate (1 := Sorts.succ (Sorts.max s0 s2)).
+    + instantiate (1 := Sorts.succ (Sorts.sum_sort s0 s2)).
       eapply type_Heq.
       * lift_sort. eapply type_llift0 ; try eassumption.
         eapply type_conv ; try eassumption.
@@ -569,7 +569,7 @@ Proof.
     subst.
     eapply type_conv.
     + eapply type_CongEq' ; eassumption.
-    + instantiate (1 := Sorts.succ s).
+    + instantiate (1 := Sorts.succ (Sorts.eq_sort s)).
       eapply type_Heq.
       * destruct (istype_type hg h1). lift_sort.
         eapply type_llift0 ; try eassumption.
@@ -669,7 +669,7 @@ Proof.
         eapply (@type_rlift1 Sort_notion) ; eassumption.
       * eapply (@type_llift1 Sort_notion) ; eassumption.
       * eapply (@type_rlift1 Sort_notion) ; eassumption.
-    + instantiate (1 := Sorts.max s0 s2).
+    + instantiate (1 := Sorts.prod_sort s0 s2).
       eapply type_Heq.
       * lift_sort. eapply type_llift0 ; try eassumption.
         destruct (istype_type hg h1).
@@ -820,7 +820,7 @@ Proof.
         apply hpv.
       * lift_sort. eapply (@type_llift1 Sort_notion) ; eassumption.
       * lift_sort. eapply (@type_rlift1 Sort_notion) ; eassumption.
-    + instantiate (1 := max s0 s2).
+    + instantiate (1 := sum_sort s0 s2).
       apply type_Heq.
       * lift_sort. eapply type_llift0 ; try eassumption.
         destruct (istype_type hg h1).
@@ -1013,7 +1013,7 @@ Proof.
     } subst.
     eapply type_conv.
     + eapply type_CongRefl' ; eassumption.
-    + instantiate (1 := s).
+    + instantiate (1 := eq_sort s).
       eapply type_Heq.
       * lift_sort. eapply type_llift0 ; try eassumption.
         destruct (istype_type hg h1).
@@ -1354,7 +1354,7 @@ Proof.
         -- apply conv_sym. eapply subj_conv ; try eassumption.
            econstructor. eapply typing_wf. eassumption.
     + ttinv ht.
-      exists (Sorts.max s1 s2). split.
+      exists (Sorts.prod_sort s1 s2). split.
       * now apply type_Prod.
       * destruct (istype_type hg ht).
         eapply type_conv ; try eassumption.
@@ -1362,7 +1362,7 @@ Proof.
         -- apply conv_sym. eapply subj_conv ; try eassumption.
            econstructor. eapply typing_wf. eassumption.
     + ttinv ht.
-      exists (Sorts.max s1 s2). split.
+      exists (Sorts.sum_sort s1 s2). split.
       * now apply type_Sum.
       * destruct (istype_type hg ht).
         eapply type_conv ; try eassumption.
@@ -1370,7 +1370,7 @@ Proof.
         -- apply conv_sym. eapply subj_conv ; try eassumption.
            econstructor. eapply typing_wf. eassumption.
     + ttinv ht.
-      exists s. split.
+      exists (eq_sort s). split.
       * now apply type_Eq.
       * destruct (istype_type hg ht).
         eapply type_conv ; try eassumption.

--- a/theories/ITyping.v
+++ b/theories/ITyping.v
@@ -27,7 +27,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
 | type_Prod Γ n t b s1 s2 :
     Σ ;;; Γ |-i t : sSort s1 ->
     Σ ;;; Γ ,, t |-i b : sSort s2 ->
-    Σ ;;; Γ |-i (sProd n t b) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-i (sProd n t b) : sSort (Sorts.prod_sort s1 s2)
 
 | type_Lambda Γ n n' t b s1 s2 bty :
     Σ ;;; Γ |-i t : sSort s1 ->
@@ -45,7 +45,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
 | type_Sum Γ n t b s1 s2 :
     Σ ;;; Γ |-i t : sSort s1 ->
     Σ ;;; Γ ,, t |-i b : sSort s2 ->
-    Σ ;;; Γ |-i (sSum n t b) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-i (sSum n t b) : sSort (Sorts.sum_sort s1 s2)
 
 | type_Pair Γ n A B u v s1 s2 :
     Σ ;;; Γ |-i A : sSort s1 ->
@@ -70,7 +70,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
     Σ ;;; Γ |-i A : sSort s ->
     Σ ;;; Γ |-i u : A ->
     Σ ;;; Γ |-i v : A ->
-    Σ ;;; Γ |-i sEq A u v : sSort s
+    Σ ;;; Γ |-i sEq A u v : sSort (Sorts.eq_sort s)
 
 | type_Refl Γ s A u :
     Σ ;;; Γ |-i A : sSort s ->
@@ -148,8 +148,8 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
     Σ ;;; Γ ,, A1 |-i B1 : sSort z ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z ->
     Σ ;;; Γ |-i sCongProd B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s z)) (sProd nx A1 B1)
-         (sSort (Sorts.max s z)) (sProd ny A2 B2)
+    sHeq (sSort (Sorts.prod_sort s z)) (sProd nx A1 B1)
+         (sSort (Sorts.prod_sort s z)) (sProd ny A2 B2)
 
 | type_CongLambda Γ s z nx ny A1 A2 B1 B2 t1 t2 pA pB pt :
     Σ ;;; Γ |-i pA : sHeq (sSort s) A1 (sSort s) A2 ->
@@ -200,8 +200,8 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
     Σ ;;; Γ ,, A1 |-i B1 : sSort z ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z ->
     Σ ;;; Γ |-i sCongSum B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s z)) (sSum nx A1 B1)
-         (sSort (Sorts.max s z)) (sSum ny A2 B2)
+    sHeq (sSort (Sorts.sum_sort s z)) (sSum nx A1 B1)
+         (sSort (Sorts.sum_sort s z)) (sSum ny A2 B2)
 
 | type_CongPair Γ s z nx ny A1 A2 B1 B2 u1 u2 v1 v2 pA pB pu pv :
     Σ ;;; Γ |-i pA : sHeq (sSort s) A1 (sSort s) A2 ->
@@ -264,7 +264,8 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Prop :=
     Σ ;;; Γ |-i v1 : A1 ->
     Σ ;;; Γ |-i v2 : A2 ->
     Σ ;;; Γ |-i sCongEq pA pu pv :
-               sHeq (sSort s) (sEq A1 u1 v1) (sSort s) (sEq A2 u2 v2)
+               sHeq (sSort (Sorts.eq_sort s)) (sEq A1 u1 v1)
+                    (sSort (Sorts.eq_sort s)) (sEq A2 u2 v2)
 
 | type_CongRefl Γ s A1 A2 u1 u2 pA pu :
     Σ ;;; Γ |-i pA : sHeq (sSort s) A1 (sSort s) A2 ->

--- a/theories/ITypingAdmissible.v
+++ b/theories/ITypingAdmissible.v
@@ -176,8 +176,8 @@ Lemma type_CongProd'' :
     Σ ;;; Γ ,, A1 |-i B1 : sSort z ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z ->
     Σ ;;; Γ |-i sCongProd B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s z)) (sProd nx A1 B1)
-         (sSort (Sorts.max s z)) (sProd ny A2 B2).
+    sHeq (sSort (Sorts.prod_sort s z)) (sProd nx A1 B1)
+         (sSort (Sorts.prod_sort s z)) (sProd ny A2 B2).
 Proof.
   intros Σ Γ s z nx ny A1 A2 B1 B2 pA pB hg hpA hpB hB1 hB2.
   destruct (istype_type hg hpA) as [? ipA]. ttinv ipA.
@@ -213,8 +213,8 @@ Lemma type_CongProd' :
     Σ ;;; Γ ,, A1 |-i B1 : sSort z1 ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z2 ->
     Σ ;;; Γ |-i sCongProd B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s1 z1)) (sProd nx A1 B1)
-         (sSort (Sorts.max s2 z2)) (sProd ny A2 B2).
+    sHeq (sSort (Sorts.prod_sort s1 z1)) (sProd nx A1 B1)
+         (sSort (Sorts.prod_sort s2 z2)) (sProd ny A2 B2).
 Proof.
   intros Σ Γ s1 s2 z1 z2 nx ny A1 A2 B1 B2 pA pB hg hpA hpB hB1 hB2.
   destruct (prod_sorts hg hpA hpB) as [e1 e2].
@@ -333,8 +333,8 @@ Lemma type_CongSum'' :
     Σ ;;; Γ ,, A1 |-i B1 : sSort z ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z ->
     Σ ;;; Γ |-i sCongSum B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s z)) (sSum nx A1 B1)
-         (sSort (Sorts.max s z)) (sSum ny A2 B2).
+    sHeq (sSort (Sorts.sum_sort s z)) (sSum nx A1 B1)
+         (sSort (Sorts.sum_sort s z)) (sSum ny A2 B2).
 Proof.
   intros Σ Γ s z nx ny A1 A2 B1 B2 pA pB hg hpA hpB hB1 hB2.
   destruct (istype_type hg hpA) as [? ipA]. ttinv ipA.
@@ -353,8 +353,8 @@ Lemma type_CongSum' :
     Σ ;;; Γ ,, A1 |-i B1 : sSort z1 ->
     Σ ;;; Γ ,, A2 |-i B2 : sSort z2 ->
     Σ ;;; Γ |-i sCongSum B1 B2 pA pB :
-    sHeq (sSort (Sorts.max s1 z1)) (sSum nx A1 B1)
-         (sSort (Sorts.max s2 z2)) (sSum ny A2 B2).
+    sHeq (sSort (Sorts.sum_sort s1 z1)) (sSum nx A1 B1)
+         (sSort (Sorts.sum_sort s2 z2)) (sSum ny A2 B2).
 Proof.
   intros Σ Γ s1 s2 z1 z2 nx ny A1 A2 B1 B2 pA pB hg hpA hpB hB1 hB2.
   destruct (prod_sorts hg hpA hpB) as [e1 e2].
@@ -507,7 +507,8 @@ Lemma type_CongEq'' :
     Σ ;;; Γ |-i pu : sHeq A1 u1 A2 u2 ->
     Σ ;;; Γ |-i pv : sHeq A1 v1 A2 v2 ->
     Σ ;;; Γ |-i sCongEq pA pu pv :
-               sHeq (sSort s) (sEq A1 u1 v1) (sSort s) (sEq A2 u2 v2).
+               sHeq (sSort (Sorts.eq_sort s)) (sEq A1 u1 v1)
+                    (sSort (Sorts.eq_sort s)) (sEq A2 u2 v2).
 Proof.
   intros Σ Γ s A1 A2 u1 u2 v1 v2 pA pu pv hg hpA hpu hpv.
   destruct (istype_type hg hpA) as [? iA]. ttinv iA.
@@ -524,8 +525,8 @@ Lemma type_CongEq' :
     Σ ;;; Γ |-i pu : sHeq A1 u1 A2 u2 ->
     Σ ;;; Γ |-i pv : sHeq A1 v1 A2 v2 ->
     Σ ;;; Γ |-i sCongEq pA pu pv
-             : sHeq (sSort s1) (sEq A1 u1 v1)
-                    (sSort s2) (sEq A2 u2 v2).
+             : sHeq (sSort (Sorts.eq_sort s1)) (sEq A1 u1 v1)
+                    (sSort (Sorts.eq_sort s2)) (sEq A2 u2 v2).
 Proof.
   intros Σ Γ s1 s2 A1 A2 u1 u2 v1 v2 pA pu pv hg hpA hpu hpv.
   destruct (istype_type hg hpA) as [? iA]. ttinv iA.

--- a/theories/ITypingInversions.v
+++ b/theories/ITypingInversions.v
@@ -40,7 +40,7 @@ Lemma inversionProd :
     exists s1 s2,
       (Σ ;;; Γ |-i A : sSort s1) *
       (Σ ;;; Γ ,, A |-i B : sSort s2) *
-      (Σ |-i sSort (Sorts.max s1 s2) = T).
+      (Σ |-i sSort (Sorts.prod_sort s1 s2) = T).
 Proof.
   intros Σ Γ n A B T h.
   dependent induction h.
@@ -93,7 +93,7 @@ Lemma inversionSum :
     exists s1 s2,
       (Σ ;;; Γ |-i A : sSort s1) *
       (Σ ;;; Γ ,, A |-i B : sSort s2) *
-      (Σ |-i sSort (Sorts.max s1 s2) = T).
+      (Σ |-i sSort (Sorts.sum_sort s1 s2) = T).
 Proof.
   intros Σ Γ n A B T h.
   dependent induction h.
@@ -162,7 +162,7 @@ Lemma inversionEq :
       (Σ ;;; Γ |-i A : sSort s) *
       (Σ ;;; Γ |-i u : A) *
       (Σ ;;; Γ |-i v : A) *
-      (Σ |-i sSort s = T).
+      (Σ |-i sSort (Sorts.eq_sort s) = T).
 Proof.
   intros Σ Γ A u v T h.
   dependent induction h.
@@ -370,8 +370,8 @@ Lemma inversionCongProd :
       (Σ ;;; Γ |-i A2 : sSort s) *
       (Σ ;;; Γ ,, A1 |-i B1 : sSort z) *
       (Σ ;;; Γ ,, A2 |-i B2 : sSort z) *
-      (Σ |-i sHeq (sSort (Sorts.max s z)) (sProd nx A1 B1)
-                 (sSort (Sorts.max s z)) (sProd ny A2 B2)
+      (Σ |-i sHeq (sSort (Sorts.prod_sort s z)) (sProd nx A1 B1)
+                 (sSort (Sorts.prod_sort s z)) (sProd ny A2 B2)
           = T).
 Proof.
   intros Σ Γ B1 B2 pA pB T h.
@@ -460,8 +460,8 @@ Lemma inversionCongSum :
       (Σ ;;; Γ |-i A2 : sSort s) *
       (Σ ;;; Γ ,, A1 |-i B1 : sSort z) *
       (Σ ;;; Γ ,, A2 |-i B2 : sSort z) *
-      (Σ |-i sHeq (sSort (Sorts.max s z)) (sSum nx A1 B1)
-                 (sSort (Sorts.max s z)) (sSum ny A2 B2)
+      (Σ |-i sHeq (sSort (Sorts.sum_sort s z)) (sSum nx A1 B1)
+                 (sSort (Sorts.sum_sort s z)) (sSum ny A2 B2)
           = T).
 Proof.
   intros Σ Γ B1 B2 pA pB T h.
@@ -575,7 +575,8 @@ Lemma inversionCongEq :
       (Σ ;;; Γ |-i u2 : A2) *
       (Σ ;;; Γ |-i v1 : A1) *
       (Σ ;;; Γ |-i v2 : A2) *
-      (Σ |-i sHeq (sSort s) (sEq A1 u1 v1) (sSort s) (sEq A2 u2 v2) = T).
+      (Σ |-i sHeq (sSort (Sorts.eq_sort s)) (sEq A1 u1 v1)
+            (sSort (Sorts.eq_sort s)) (sEq A2 u2 v2) = T).
 Proof.
   intros Σ Γ pA pu pv T h.
   dependent induction h.

--- a/theories/ITypingLemmata.v
+++ b/theories/ITypingLemmata.v
@@ -1004,8 +1004,8 @@ Proof.
            ++ erewrite eq_safe_nth. eassumption.
            ++ eassumption.
   - exists (Sorts.succ (Sorts.succ s)). now apply type_Sort.
-  - exists (Sorts.succ (Sorts.max s1 s2)). apply type_Sort. apply (typing_wf H).
-  - exists (Sorts.max s1 s2). apply type_Prod ; assumption.
+  - eexists. apply type_Sort. apply (typing_wf H).
+  - eexists. apply type_Prod ; eassumption.
   - exists s2. change (sSort s2) with ((sSort s2){ 0 := u }).
     eapply typing_subst ; eassumption.
   - eexists. econstructor. eapply typing_wf. eassumption.
@@ -1014,8 +1014,8 @@ Proof.
   - exists s2. change (sSort s2) with ((sSort s2){ 0 := sPi1 A B p }).
     eapply typing_subst ; try eassumption.
     econstructor ; eassumption.
-  - exists (Sorts.succ s). apply type_Sort. apply (typing_wf H).
-  - exists s. now apply type_Eq.
+  - eexists. apply type_Sort. apply (typing_wf H).
+  - eexists. now apply type_Eq.
   - exists s2.
     change (sSort s2) with ((sSort s2){1 := v}{0 := p}).
     eapply typing_subst2.
@@ -1026,20 +1026,20 @@ Proof.
       assumption.
   - eexists. eassumption.
   - exists (Sorts.succ s). apply type_Sort. apply (typing_wf H).
-  - exists s. apply type_Eq ; assumption.
+  - eexists. apply type_Eq ; eassumption.
   - exists s. apply type_Heq ; assumption.
   - exists s. apply type_Heq ; assumption.
   - exists s. apply type_Heq ; assumption.
   - exists s. apply type_Heq. all: try assumption.
     eapply type_Transport ; eassumption.
-  - exists (Sorts.succ (Sorts.max s z)).
+  - eexists.
     apply type_Heq.
     + eapply type_Sort. apply (typing_wf H).
     + eapply type_Sort. apply (typing_wf H).
     + apply type_Prod ; assumption.
     + apply type_Prod ; assumption.
-  - exists (Sorts.max s z). apply type_Heq.
-    + apply type_Prod ; assumption.
+  - eexists. apply type_Heq.
+    + apply type_Prod ; eassumption.
     + apply type_Prod ; assumption.
     + eapply type_Lambda ; eassumption.
     + eapply type_Lambda ; eassumption.
@@ -1050,7 +1050,7 @@ Proof.
       eapply typing_subst ; eassumption.
     + eapply type_App ; eassumption.
     + eapply type_App ; eassumption.
-  - exists (Sorts.succ (Sorts.max s z)).
+  - eexists.
     apply type_Heq.
     + eapply type_Sort. apply (typing_wf H).
     + eapply type_Sort. apply (typing_wf H).
@@ -1079,18 +1079,18 @@ Proof.
       econstructor ; eassumption.
     + econstructor ; eassumption.
     + econstructor ; eassumption.
-  - exists (Sorts.succ s). apply type_Heq.
+  - eexists. apply type_Heq.
     + apply type_Sort ; apply (typing_wf H).
     + apply type_Sort ; apply (typing_wf H).
     + apply type_Eq ; assumption.
     + apply type_Eq ; assumption.
-  - exists s. apply type_Heq.
-    + apply type_Eq ; assumption.
+  - eexists. apply type_Heq.
+    + apply type_Eq ; eassumption.
     + apply type_Eq ; assumption.
     + eapply type_Refl ; eassumption.
     + eapply type_Refl ; eassumption.
   - exists s. apply type_Heq ; assumption.
-  - exists (Sorts.succ s). eapply type_Eq ; try assumption.
+  - eexists. eapply type_Eq ; try assumption.
     apply type_Sort. apply (typing_wf H).
   - exists (Sorts.succ s). apply type_Sort. apply (typing_wf H).
   - exists s. assumption.

--- a/theories/Translation.v
+++ b/theories/Translation.v
@@ -57,8 +57,8 @@ Definition trans_Prod {Σ Γ n A B s1 s2 Γ' A' B'} :
   Σ ;;;; Γ' |--- [A'] : sSort s1 # ⟦ Γ |--- [A] : sSort s1 ⟧ ->
   Σ ;;;; Γ' ,, A' |--- [B'] : sSort s2
   # ⟦ Γ ,, A |--- [B]: sSort s2 ⟧ ->
-  Σ ;;;; Γ' |--- [sProd n A' B']: sSort (Sorts.max s1 s2)
-  # ⟦ Γ |--- [ sProd n A B]: sSort (Sorts.max s1 s2) ⟧.
+  Σ ;;;; Γ' |--- [sProd n A' B']: sSort (Sorts.prod_sort s1 s2)
+  # ⟦ Γ |--- [ sProd n A B]: sSort (Sorts.prod_sort s1 s2) ⟧.
 Proof.
   intros hΓ hA hB.
   destruct hΓ. destruct hA as [[? ?] ?]. destruct hB as [[? ?] ?].
@@ -74,8 +74,8 @@ Definition trans_Sum {Σ Γ n A B s1 s2 Γ' A' B'} :
   Σ ;;;; Γ' |--- [A'] : sSort s1 # ⟦ Γ |--- [A] : sSort s1 ⟧ ->
   Σ ;;;; Γ' ,, A' |--- [B'] : sSort s2
   # ⟦ Γ ,, A |--- [B]: sSort s2 ⟧ ->
-  Σ ;;;; Γ' |--- [sSum n A' B']: sSort (Sorts.max s1 s2)
-  # ⟦ Γ |--- [ sSum n A B]: sSort (Sorts.max s1 s2) ⟧.
+  Σ ;;;; Γ' |--- [sSum n A' B']: sSort (Sorts.sum_sort s1 s2)
+  # ⟦ Γ |--- [ sSum n A B]: sSort (Sorts.sum_sort s1 s2) ⟧.
 Proof.
   intros hΓ hA hB.
   destruct hΓ. destruct hA as [[? ?] ?]. destruct hB as [[? ?] ?].
@@ -91,7 +91,8 @@ Definition trans_Eq {Σ Γ A u v s Γ' A' u' v'} :
   Σ ;;;; Γ' |--- [A'] : sSort s # ⟦ Γ |--- [A] : sSort s ⟧ ->
   Σ ;;;; Γ' |--- [u'] : A' # ⟦ Γ |--- [u] : A ⟧ ->
   Σ ;;;; Γ' |--- [v'] : A' # ⟦ Γ |--- [v] : A ⟧ ->
-  Σ ;;;; Γ' |--- [sEq A' u' v'] : sSort s # ⟦ Γ |--- [sEq A u v] : sSort s ⟧.
+  Σ ;;;; Γ' |--- [sEq A' u' v'] : sSort (Sorts.eq_sort s) 
+  # ⟦ Γ |--- [sEq A u v] : sSort (Sorts.eq_sort s) ⟧.
 Proof.
   intros hΓ hA hu hv.
   destruct hA as [[[? ?] ?] ?].
@@ -241,7 +242,7 @@ Proof.
       clear hb' b' S'.
       destruct T' ; inversion hh. subst. clear hh th.
       (* Now we conclude *)
-      exists (sSort (Sorts.max s1 s2)), (sProd n t'' b'').
+      exists (sSort (Sorts.prod_sort s1 s2)), (sProd n t'' b'').
       now apply trans_Prod.
 
     (* type_Lambda *)
@@ -331,7 +332,7 @@ Proof.
       clear hb' b' S'.
       destruct T' ; inversion hh. subst. clear hh th.
       (* Now we conclude *)
-      exists (sSort (Sorts.max s1 s2)), (sSum n t'' b'').
+      exists (sSort (Sorts.sum_sort s1 s2)), (sSum n t'' b'').
       now apply trans_Sum.
 
     (* type_Pair *)
@@ -456,7 +457,7 @@ Proof.
       destruct (X1 _ hΓ) as [A'' [v'' hv'']].
       destruct (change_type hg hv'' hA') as [v' hv'].
       (* Now we conclude *)
-      exists (sSort s), (sEq A' u' v').
+      exists (sSort (Sorts.eq_sort s)), (sEq A' u' v').
       apply trans_Eq ; assumption.
 
     (* type_Refl *)
@@ -904,7 +905,7 @@ Proof.
       }
       destruct hp5 as [p5 hp5].
       (* We can finally conclude! *)
-      exists (sSort (Sorts.max s1 s2)), (sSort (Sorts.max s1 s2)).
+      exists (sSort (Sorts.prod_sort s1 s2)), (sSort (Sorts.prod_sort s1 s2)).
       exists (sProd n1 A1' B1'), (sProd n2 A2' tB2).
       exists (sCongProd B1' tB2 p1 p5).
       destruct hA1' as [[[? ?] ?] ?].
@@ -1152,8 +1153,10 @@ Proof.
          This is where the path between the two types comes into action.
        *)
       assert (hty : ∑ pty,
-        Σ ;;; Γ' |-i pty : sHeq (sSort (Sorts.max s1 s2)) (sProd n2 A2' B2')
-                               (sSort (Sorts.max s1 s2)) (sProd n1 A1' B1')
+        Σ ;;; Γ' |-i pty : sHeq (sSort (Sorts.prod_sort s1 s2)) 
+                               (sProd n2 A2' B2')
+                               (sSort (Sorts.prod_sort s1 s2))
+                               (sProd n1 A1' B1')
 
       ).
       { exists (optHeqSym (sCongProd B1' B2' pA pB)).
@@ -1622,7 +1625,7 @@ Proof.
       }
       destruct hp5 as [p5 hp5].
       (* We can finally conclude! *)
-      exists (sSort (Sorts.max s1 s2)), (sSort (Sorts.max s1 s2)).
+      exists (sSort (Sorts.sum_sort s1 s2)), (sSort (Sorts.sum_sort s1 s2)).
       exists (sSum n1 A1' B1'), (sSum n2 A2' tB2).
       exists (sCongSum B1' tB2 p1 p5).
       destruct hA1' as [[[? ?] ?] ?].
@@ -2511,7 +2514,8 @@ Proof.
         - eapply type_HeqTransport ; eassumption.
       }
       destruct hq as [qv' hqv'].
-      exists (sSort s), (sSort s), (sEq tA1 tu1 tv1), (sEq tA2 ttu2 ttv2).
+      exists (sSort (Sorts.eq_sort s)), (sSort (Sorts.eq_sort s)).
+      exists (sEq tA1 tu1 tv1), (sEq tA2 ttu2 ttv2).
       exists (sCongEq qA qu' qv').
       destruct htu1 as [[[? ?] ?] ?].
       destruct htu2 as [[[? ?] ?] ?].
@@ -2520,6 +2524,8 @@ Proof.
       destruct htv1 as [[[? ?] ?] ?].
       destruct htv2 as [[[? ?] ?] ?].
       repeat split ; try eassumption.
+      * econstructor ; assumption.
+      * econstructor ; assumption.
       * econstructor ; assumption.
       * econstructor ; try assumption.
         -- econstructor ; eassumption.
@@ -2612,15 +2618,17 @@ Proof.
       destruct hq as [q hq].
       (* We're still not there yet as we need to have two translations of the
          same type. *)
-      assert (pE : ∑ pE, Σ ;;; Γ' |-i pE : sHeq (sSort s) (sEq tA2 ttu2 ttu2)
-                                               (sSort s) (sEq tA1 tu1 tu1)).
+      assert (pE : ∑ pE, Σ ;;; Γ' |-i pE : 
+                         sHeq (sSort (Sorts.eq_sort s)) (sEq tA2 ttu2 ttu2)
+                              (sSort (Sorts.eq_sort s)) (sEq tA1 tu1 tu1)).
       { exists (optHeqSym (sCongEq qA q q)).
         eapply opt_HeqSym ; try assumption.
         eapply type_CongEq' ; eassumption.
       }
       destruct pE as [pE hpE].
-      assert (eE : ∑ eE, Σ ;;; Γ' |-i eE : sEq (sSort s) (sEq tA2 ttu2 ttu2)
-                                              (sEq tA1 tu1 tu1)).
+      assert (eE : ∑ eE, Σ ;;; Γ' |-i eE : 
+                         sEq (sSort (Sorts.eq_sort s)) (sEq tA2 ttu2 ttu2)
+                             (sEq tA1 tu1 tu1)).
       { eapply (opt_sort_heq_ex hg hpE). }
       destruct eE as [eE hE].
       pose (trefl2 := sTransport (sEq tA2 ttu2 ttu2)
@@ -2688,7 +2696,7 @@ Proof.
     - constructor.
     - constructor.
     - apply inrel_refl. repeat constructor.
-    - change 1 with (Sorts.max 1 0). econstructor.
+    - change 1 with (Sorts.prod_sort 1 0). econstructor.
       + econstructor. constructor.
       + refine (type_Rel _ _ _ _ _).
         * repeat econstructor.

--- a/theories/Uniqueness.v
+++ b/theories/Uniqueness.v
@@ -175,8 +175,9 @@ Proof.
     pose proof (heq_conv_inv IHu2).
     pose proof (heq_conv_inv IHu3).
     split_hyps. subst.
+    pose proof (sort_conv_inv pi1_1). subst.
     eapply conv_trans ; [| exact h13 ].
-    apply cong_Heq ; try assumption.
+    apply cong_Heq ; try apply conv_refl.
     + apply cong_Eq ; assumption.
     + apply cong_Eq ; assumption.
   - specialize (IHu1 _ _ _ h h0).

--- a/theories/XTyping.v
+++ b/theories/XTyping.v
@@ -25,7 +25,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Type :=
 | type_Prod Γ n t b s1 s2 :
     Σ ;;; Γ |-x t : sSort s1 ->
     Σ ;;; Γ ,, t |-x b : sSort s2 ->
-    Σ ;;; Γ |-x (sProd n t b) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-x (sProd n t b) : sSort (Sorts.prod_sort s1 s2)
 
 | type_Lambda Γ n n' t b s1 s2 bty :
     Σ ;;; Γ |-x t : sSort s1 ->
@@ -43,7 +43,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Type :=
 | type_Sum Γ n t b s1 s2 :
     Σ ;;; Γ |-x t : sSort s1 ->
     Σ ;;; Γ ,, t |-x b : sSort s2 ->
-    Σ ;;; Γ |-x (sSum n t b) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-x (sSum n t b) : sSort (Sorts.sum_sort s1 s2)
 
 | type_Pair Γ n A B u v s1 s2 :
     Σ ;;; Γ |-x A : sSort s1 ->
@@ -68,7 +68,7 @@ Inductive typing (Σ : sglobal_context) : scontext -> sterm -> sterm -> Type :=
     Σ ;;; Γ |-x A : sSort s ->
     Σ ;;; Γ |-x u : A ->
     Σ ;;; Γ |-x v : A ->
-    Σ ;;; Γ |-x sEq A u v : sSort s
+    Σ ;;; Γ |-x sEq A u v : sSort (Sorts.eq_sort s)
 
 | type_Refl Γ s A u :
     Σ ;;; Γ |-x A : sSort s ->
@@ -128,7 +128,8 @@ with eq_term (Σ : sglobal_context) : scontext -> sterm -> sterm -> sterm -> Typ
     Σ ;;; Γ ,, A1 |-x B1 = B2 : sSort s2 ->
     Σ ;;; Γ ,, A1 |-x B1 : sSort s2 ->
     Σ ;;; Γ ,, A2 |-x B2 : sSort s2 ->
-    Σ ;;; Γ |-x (sProd n1 A1 B1) = (sProd n2 A2 B2) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-x (sProd n1 A1 B1) = (sProd n2 A2 B2) : 
+               sSort (Sorts.prod_sort s1 s2)
 
 | cong_Lambda Γ n1 n2 n' A1 A2 B1 B2 t1 t2 s1 s2 :
     Σ ;;; Γ |-x A1 = A2 : sSort s1 ->
@@ -158,7 +159,7 @@ with eq_term (Σ : sglobal_context) : scontext -> sterm -> sterm -> sterm -> Typ
     Σ ;;; Γ ,, A1 |-x B1 = B2 : sSort s2 ->
     Σ ;;; Γ ,, A1 |-x B1 : sSort s2 ->
     Σ ;;; Γ ,, A2 |-x B2 : sSort s2 ->
-    Σ ;;; Γ |-x (sSum n1 A1 B1) = (sSum n2 A2 B2) : sSort (Sorts.max s1 s2)
+    Σ ;;; Γ |-x (sSum n1 A1 B1) = (sSum n2 A2 B2) : sSort (Sorts.sum_sort s1 s2)
 
 | cong_Pair Γ n A1 A2 B1 B2 u1 u2 v1 v2 s1 s2 :
     Σ ;;; Γ |-x A1 = A2 : sSort s1 ->
@@ -197,7 +198,7 @@ with eq_term (Σ : sglobal_context) : scontext -> sterm -> sterm -> sterm -> Typ
     Σ ;;; Γ |-x A1 = A2 : sSort s ->
     Σ ;;; Γ |-x u1 = u2 : A1 ->
     Σ ;;; Γ |-x v1 = v2 : A1 ->
-    Σ ;;; Γ |-x sEq A1 u1 v1 = sEq A2 u2 v2 : sSort s
+    Σ ;;; Γ |-x sEq A1 u1 v1 = sEq A2 u2 v2 : sSort (Sorts.eq_sort s)
 
 | cong_Refl Γ s A1 A2 u1 u2 :
     Σ ;;; Γ |-x A1 = A2 : sSort s ->


### PR DESCRIPTION
The file of interest here is `Sorts.v`. The rest is merely adapting the files (and the typing rules so that equality is always strict).

```coq
Class notion := {
  sort : Type ;
  succ : sort -> sort ;
  prod_sort : sort -> sort -> sort ;
  sum_sort : sort -> sort -> sort ;
  eq_sort : sort -> sort ;
  eq_dec : forall s z : sort, {s = z} + {s <> z} ;
  succ_inj : forall s z, succ s = succ z -> s = z
}.
```

```coq
Inductive twolevel := F (n : nat) | U (n : nat).
Local Instance twolevel_sorts : notion := {|
  sort := twolevel ;
  succ s := 
    match s with 
    | U n => U (S n)
    | F n => F (S n)
    end ;
  prod_sort s1 s2 :=
    match s1, s2 with
    | U n, U m => U (Nat.max n m)
    | F n, F m => F (Nat.max n m)
    | U n, F m => U (Nat.max n m)
    | F n, U m => U (Nat.max n m)
    end ;
  sum_sort s1 s2 :=
    match s1, s2 with
    | U n, U m => U (Nat.max n m)
    | F n, F m => F (Nat.max n m)
    | U n, F m => U (Nat.max n m)
    | F n, U m => U (Nat.max n m)
    end ;
  eq_sort s :=
    match s with
    | U n => U n
    | F n => U n
    end
|}.
```